### PR TITLE
add tag for items that lose nbt on duplication

### DIFF
--- a/src/main/java/com/acikek/theprinter/ThePrinter.java
+++ b/src/main/java/com/acikek/theprinter/ThePrinter.java
@@ -2,6 +2,7 @@ package com.acikek.theprinter;
 
 import com.acikek.theprinter.block.PrinterBlock;
 import com.acikek.theprinter.block.PrinterBlockEntity;
+import com.acikek.theprinter.data.ModTags;
 import com.acikek.theprinter.sound.ModSoundEvents;
 import com.acikek.theprinter.world.ModGameRules;
 import com.acikek.theprinter.world.PrinterRuleReloader;
@@ -34,6 +35,7 @@ public class ThePrinter implements ModInitializer {
 		PrinterBlockEntity.register();
 		ModSoundEvents.register();
 		ModGameRules.register();
+		ModTags.register();
 		PrinterRuleReloader.register();
 		registerDatapack();
 	}

--- a/src/main/java/com/acikek/theprinter/block/PrinterBlockEntity.java
+++ b/src/main/java/com/acikek/theprinter/block/PrinterBlockEntity.java
@@ -4,6 +4,7 @@ import com.acikek.datacriteria.api.DataCriteriaAPI;
 import com.acikek.theprinter.ThePrinter;
 import com.acikek.theprinter.data.PrinterRule;
 import com.acikek.theprinter.data.PrinterRules;
+import com.acikek.theprinter.data.ModTags;
 import com.acikek.theprinter.sound.ModSoundEvents;
 import com.acikek.theprinter.util.PrinterExperienceOrbEntity;
 import com.acikek.theprinter.world.ModGameRules;
@@ -261,6 +262,9 @@ public class PrinterBlockEntity extends BlockEntity {
 	public void startPrinting(World world, BlockPos pos, BlockState state) {
 		world.setBlockState(pos, state.with(PrinterBlock.PRINTING, true));
 		ItemStack printingStack = getItems().get(0).copy();
+		if (printingStack.isIn(ModTags.LOSES_NBT)) {
+			printingStack.setNbt(null);
+		}
 		modifyPrintingStack(world, printingStack);
 		getItems().set(1, printingStack);
 		// Add one to the tick offset since the sound will begin next tick

--- a/src/main/java/com/acikek/theprinter/data/ModTags.java
+++ b/src/main/java/com/acikek/theprinter/data/ModTags.java
@@ -1,0 +1,20 @@
+package com.acikek.theprinter.data;
+
+import com.acikek.theprinter.ThePrinter;
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+
+public class ModTags {
+	public static TagKey<Item> LOSES_NBT;
+
+	public static TagKey<Item> register(String path) {
+		Identifier id = ThePrinter.id(path);
+		return TagKey.of(Registries.ITEM.getKey(), id);
+	}
+
+	public static void register() {
+		LOSES_NBT = register("loses_nbt");
+	}
+}


### PR DESCRIPTION
adds an nbt tag to make specific items lose their nbt when duplicating

works through tag to avoid changing printer rule system